### PR TITLE
Add fish shell support to installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,8 @@ if [[ $(echo $SHELL | grep bash) ]]; then
     RC_FILE=$HOME/.bashrc
 elif [[ $(echo $SHELL | grep zsh) ]]; then
     RC_FILE=$HOME/.zshrc
+elif [[ $(echo $SHELL | grep fish) ]]; then
+    RC_FILE=$HOME/.config/fish/config.fish
 else
   echo "Unknown shell type!"
   echo "You'll have to set up aliases on your own."


### PR DESCRIPTION
The [fish](http://fishshell.com/) shell has its own scripting language slightly different from bash, but running `./install.sh` in fish still runs the script properly as a bash script. Fish supports most bash functionality, so adding the aliases to the fish config file is all that's needed, just as for bash and zsh. All of the commands worked great when I tested.
