### PR TITLE
Added fullscreen toggle script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Default aliases:
 * `cen` - center the window
 * `max` - maximize the window
 * `sn` - move to the next display
+* `fs` - toggles terminal app fullscreen
 
 You can always customize them on your own. They always look like this:
 
@@ -95,6 +96,10 @@ Maximizes the window.
 
 Moves the window to another screen. Currently only supports
 moving to the next display on a list.
+
+**fullscreen.applescript**
+
+Toggles fullscreen for the terminal app.
 
 
 Contributing

--- a/install.sh
+++ b/install.sh
@@ -167,6 +167,7 @@ if [[ $RC_FILE ]]; then
     create_alias "cen" "center.scpt"
     create_alias "max" "maximize.scpt"
     create_alias "sn" "changeScreen.scpt" "next"
+    create_alias "fs" "fullscreen.scpt"
     echo "$rc_append" >> "$RC_FILE"
   fi
 fi

--- a/src/fullscreen.applescript
+++ b/src/fullscreen.applescript
@@ -1,0 +1,13 @@
+global _cache
+set _cache to {}
+
+set _config to run script alias ((path to me as text) & "::config.scpt")
+
+set _terminalApp to terminalApp of _config
+
+if (offset of "iTerm" in _terminalApp) is not 0 then
+	-- key code 36 is the return key
+	tell application "System Events" to key code 36 using command down
+else
+	tell application "System Events" to keystroke "f" using {command down, control down}
+end if


### PR DESCRIPTION
Added fullscreen toggle script with default alias `fs` (fixes #2)

This turned out to be a little weirder than I would have thought (There's no "tell app fullscreen"). There were two possible ways I found to do this:
1. Have the applescript perform a keystroke to mimic the fullscreen shortcut in the terminal app
2. Have the applescript perform a mouse click to click the fullscreen button

Option 2. require terminal to have accessibility enabled, so I went with option 1. The fullscreen shortcut for most OS X apps is F + CTRL + CMD, but in iTerm it's RETURN + CMD. So right now, the script checks if you're using iTerm as your default terminal app to determine which keystroke to use.

One issue I can't figure out is that in zsh and fish (but not bash), sending the keystroke to exit fullscreen sometimes seems to send a newline with it (attached fish screenshot)

<img width="222" alt="screenshot 2015-08-18 18 33 28" src="https://cloud.githubusercontent.com/assets/6855546/9344790/35d6e9cc-45d9-11e5-8cda-2aa21cfe9e8b.png">

This doesn't cause any functionality issues, but it would be nice to get rid of if anyone can think of why it's happening.

Tested it in Terminal and iTerm 2 using bash, zsh, and fish.
