### PR TITLE
Cleaned up dock handling

### DIFF
--- a/src/getScreenInfo.m
+++ b/src/getScreenInfo.m
@@ -9,36 +9,43 @@ void printScreenInfo() {
     NSUInteger screenCount = [screenArray count];
 
     printf("%lu\n", (unsigned long)[screenArray count]);
-
-    NSRect mainFrame = [[screenArray objectAtIndex:0] frame];
-
-    CGFloat offsetBottom = 0;
+    
+    NSRect mainFrame = [[NSScreen mainScreen] frame];
+    
+    CGFloat diffHeight;
+    CGFloat diffWidth;
+    
     NSInteger dockScreenIndex = -1;
     for (NSUInteger index = 0; index < screenCount; index++)
     {
-        NSScreen *screen = [screenArray objectAtIndex: index];
+        NSScreen *screen = screenArray[index];
+        
+        // visibleFrame does not include menubar or dock
         screenVisibleRect = [screen visibleFrame];
         screenRect = [screen frame];
-        CGFloat diffHeight = screenRect.size.height - screenVisibleRect.size.height;
+        
+        diffHeight = screenRect.size.height - screenVisibleRect.size.height;
+        diffWidth = screenRect.size.width - screenVisibleRect.size.width;
+        
+        // account for the menu bar on the primary screen
         diffHeight -= index == 0 ? MENU_HEIGHT : 0;
-
-        if (diffHeight != 0) {
+        
+        // use FLT_EPSILON to avoid exact comparisons of floats
+        if (diffHeight > FLT_EPSILON || diffWidth > FLT_EPSILON) {
             dockScreenIndex = index;
-            offsetBottom = diffHeight;
             break;
         }
     }
-
-    printf("%.0f %lu\n", offsetBottom, dockScreenIndex + 1);
+    
+    printf("%.0f %.0f %lu\n", diffHeight, diffWidth, dockScreenIndex + 1);
 
     for (NSUInteger index = 0; index < screenCount; index++)
     {
         NSScreen *screen = [screenArray objectAtIndex: index];
-        screenVisibleRect = [screen visibleFrame];
         screenRect = [screen frame];
         CGFloat upperLeftY = -screenRect.origin.y - screenRect.size.height + mainFrame.size.height + MENU_HEIGHT;
         CGFloat height = screenRect.size.height - MENU_HEIGHT;
-        printf("%.0f %.0f %.0f %.0f\n",screenRect.origin.x, upperLeftY, screenRect.size.width, height);
+        printf("%.0f %.0f %.0f %.0f\n", screenRect.origin.x, upperLeftY, screenRect.size.width, height);
     }
 }
 


### PR DESCRIPTION
Fixes #22 

I couldn't figure out if that 16px difference between the dock height and the tile size is a constant or not, so it seems like using the Obj-C to to calculate the difference between the frame and the visibleScreen is the most reliable solution without needing assistive devices enabled. I think the reason the Obj-C utility might have been unreliable before and sometimes wouldn't detect the dock is that it was comparing `diffHeight != 0` which could fail due to floating point imprecision. I tried to fix this by comparing `diffHeight` and `diffWidth` to `FLT_EPSILON` which is a very small, non-zero constant that should account for any weird floating point problems.

Overall, I kept the main logic similar but added in checks needed for left/right dock support.

One case that seems a bit weird is that it appears when the dock is set to auto-hide, there's a small region used to detect the mouse-over that is 4 px tall for me. I'm not sure if this 4 px is a constant that we could account for when the dock is autohiding. 

Tested on a two monitor setup in Terminal and iTerm. I will keep testing this out and see if I find any issues, but I thought I would put this PR up so others could take a look and test.
